### PR TITLE
Fixed readme to specify paths can be relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The WriteAPI Output Plugin enables a customer to send data to Google BigQuery wi
     Parsers_File    path/to/jsonparser.conf
     plugins_file    path/to/plugins.conf
 ```
-The `Parsers_File` field points to the parsing of your input and the `plugins_file` field is the path to the plugin you wish to use. The paths here are the absolute paths to the files.
+The `Parsers_File` field points to the parsing of your input and the `plugins_file` field is the path to the plugin you wish to use. The paths here are the absolute or relative paths to the files.
 
 Here is an example of a `INPUT` section:
 ```
@@ -56,7 +56,7 @@ Here is an example of a `INPUT` section:
     Parser  json
     Tag     logfile1
 ```
-This establishes an input with the name `tail` with a specified path which uses the `json` parser specified in the `SERVICES` section. The tag is the most important part to take note of here, as this will be used to find matches for relevant outputs. The paths here is the absolute path to the file. 
+This establishes an input with the name `tail` with a specified path which uses the `json` parser specified in the `SERVICES` section. The tag is the most important part to take note of here, as this will be used to find matches for relevant outputs. The paths here is the absolute or relative path to the file. 
 
 Here is an example of an `OUTPUT` section:
 ```

--- a/app/logfile.log
+++ b/app/logfile.log
@@ -49,3 +49,7 @@
 {"Time":"2024-06-28T21:26:17Z","Text":"Hello World!"}
 {"Time":"2024-06-28T21:26:18Z","Text":"Hello World!"}
 {"Time":"2024-06-28T21:26:19Z","Text":"Hello World!"}
+{"Time":"2024-07-09T20:36:31Z","Text":"Hello World!"}
+{"Time":"2024-07-09T20:36:32Z","Text":"Hello World!"}
+{"Time":"2024-07-09T20:36:33Z","Text":"Hello World!"}
+{"Time":"2024-07-09T20:36:34Z","Text":"Hello World!"}

--- a/app/logfile.log
+++ b/app/logfile.log
@@ -49,7 +49,3 @@
 {"Time":"2024-06-28T21:26:17Z","Text":"Hello World!"}
 {"Time":"2024-06-28T21:26:18Z","Text":"Hello World!"}
 {"Time":"2024-06-28T21:26:19Z","Text":"Hello World!"}
-{"Time":"2024-07-09T20:36:31Z","Text":"Hello World!"}
-{"Time":"2024-07-09T20:36:32Z","Text":"Hello World!"}
-{"Time":"2024-07-09T20:36:33Z","Text":"Hello World!"}
-{"Time":"2024-07-09T20:36:34Z","Text":"Hello World!"}

--- a/expipeline.conf
+++ b/expipeline.conf
@@ -1,11 +1,11 @@
 [SERVICE]
     Daemon          off
     Log_Level       error
-    Parsers_File    /usr/local/google/home/raahi/summer2024_code/out_writeapi/jsonparser.conf
-    plugins_file    /usr/local/google/home/raahi/summer2024_code/out_writeapi/plugins.conf
+    Parsers_File    ./jsonparser.conf
+    plugins_file    ./plugins.conf
 [INPUT]
     Name                               tail
-    Path                               /usr/local/google/home/raahi/summer2024_code/out_writeapi/app/logfile.log
+    Path                               ./app/logfile.log
     Parser                             json
 [OUTPUT]
     Name                               writeapi

--- a/plugins.conf
+++ b/plugins.conf
@@ -1,2 +1,2 @@
 [PLUGINS]
-    Path /usr/local/google/home/tpuhan/fluent-bit/out_writeapi/out_writeapi.so
+    Path ./out_writeapi.so

--- a/tanip_pipeline.conf
+++ b/tanip_pipeline.conf
@@ -2,12 +2,12 @@
     Flush           1
     Daemon          off
     Log_Level       error
-    Parsers_File    /usr/local/google/home/tpuhan/fluent-bit/out_writeapi/jsonparser.conf
-    plugins_file    /usr/local/google/home/tpuhan/fluent-bit/out_writeapi/plugins.conf
+    Parsers_File    ./jsonparser.conf
+    plugins_file    ./plugins.conf
 
 [INPUT]
     Name    tail
-    Path    /usr/local/google/home/tpuhan/fluent-bit/out_writeapi/app/logfile.log
+    Path    ./app/logfile.log
     Parser  json
     Tag     logfile1
 


### PR DESCRIPTION
I retried the relative paths and it works now. I must've been wrong back then, but I am sure now that the relative paths work. I updated the README to reflect this.